### PR TITLE
add xacro and nlohmann dependency

### DIFF
--- a/go2_description/package.xml
+++ b/go2_description/package.xml
@@ -12,6 +12,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <exec_depend>xacro</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/go2_driver/package.xml
+++ b/go2_driver/package.xml
@@ -19,6 +19,7 @@
   <depend>unitree_api</depend>
   <depend>tf2_ros</depend>
   <depend>go2_interfaces</depend>
+  <depend>nlohmann-json-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
When installing the package the first time on the Go2, I received two dependency errors.

The first one for nlohmann/json:
```
--- stderr: go2_driver                                    
[...]
fatal error: nlohmann/json.hpp: No such file or directory
   45 | #include "nlohmann/json.hpp"
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/go2_driver.dir/build.make:63: CMakeFiles/go2_driver.dir/src/go2_driver/go2_driver.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/go2_driver.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
Failed   <<< go2_driver [6.68s, exited with code 2]
``` 

and a second when launching 

`ros2 launch go2_bringup go2.launch.py`

which resulted from a missing xacro installation on the robot